### PR TITLE
Update .python-lint to disable misfunctioning parameter rule

### DIFF
--- a/.github/linters/.python-lint
+++ b/.github/linters/.python-lint
@@ -65,7 +65,8 @@ disable=raw-checker-failed,
         import-error,
         E0602,
         E1101,
-        E0213
+        E0213,
+        E1123
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
Let there be green!